### PR TITLE
修复脚本，整理代码

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12.11-alpine
+
+WORKDIR /app
+
+COPY wut-login.py /app/wut-login.py
+
+RUN adduser -S whut && \
+    addgroup -S whut && \
+    chown -R whut:whut /app && \
+    pip install --no-cache-dir requests
+
+# Run as non-root user
+USER whut
+
+CMD ["python", "wut-login.py"]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,45 @@
 
 ![Apache 2.0 license](https://img.shields.io/hexpm/l/plug) ![Python3](https://img.shields.io/pypi/pyversions/P)
 
-武汉理工大学 校园网自动登录器
-当前版本 v0.1
+武汉理工大学 校园网自动登录器  
 
-用于武汉理工大学校园网的长时间无人值守自动登陆及掉线重登
+* 当前版本 `v0.2`  
+* 用于武汉理工大学校园网的长时间无人值守自动登陆及掉线重登  
 
-使用需要Python3，并需要确认已安装json和requests包
+使用需要 Python3，并需要确认已安装 `requests` 包。  
 
-使用方法：
-python3 wut-login.py
+## 使用方式
+
+### 1. 基于环境变量
+
+```sh
+export WUT_USERID='100110' # 你的校园卡号(校园网账号)
+export WUT_PASSWD='El_psy_kongroo' # 你的校园网密码
+export CHECK_INTERVAL=60 # (可选)检测间隔，单位为秒，如果不配置则默认为 600 秒
+
+python wut-login.py
+```
+
+### 2. 直接改脚本文件运行
+
+修改 `wut-login.py` 头部的配置即可:  
+
+```python
+userid = os.getenv("WUT_USERID", "你的账号")  # Read from environment variable by default
+passwd = os.getenv("WUT_PASSWD", "你的密码")
+interval = int(os.getenv("CHECK_INTERVAL", 600))  # Default interval is 600 seconds
+```
+
+### 3. 使用 Docker
+
+```sh
+docker pull somebottle/whut-online-keeper:0.2
+
+# --restart unless-stopped 在进程意外终止 / 关机重启 / Docker Daemon 重启等情况下自动重启
+docker run -d --name whut-online-keeper \
+    --restart unless-stopped \
+    -e WUT_USERID='100110' \
+    -e WUT_PASSWD='El_psy_kongroo' \
+    -e CHECK_INTERVAL=60 \
+    somebottle/whut-online-keeper:0.2
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 武汉理工大学 校园网自动登录器  
 
-* 当前版本 `v0.2`  
+* 当前版本 `v0.3`  
 * 用于武汉理工大学校园网的长时间无人值守自动登陆及掉线重登  
 
 使用需要 Python3，并需要确认已安装 `requests` 包。  
@@ -17,6 +17,7 @@
 export WUT_USERID='100110' # 你的校园卡号(校园网账号)
 export WUT_PASSWD='El_psy_kongroo' # 你的校园网密码
 export CHECK_INTERVAL=60 # (可选)检测间隔，单位为秒，如果不配置则默认为 600 秒
+export LOG_LEVEL=1 # (可选)日志级别，0 为最简化输出，1 为详细日志，默认为 1
 
 python wut-login.py
 ```
@@ -29,18 +30,20 @@ python wut-login.py
 userid = os.getenv("WUT_USERID", "你的账号")  # Read from environment variable by default
 passwd = os.getenv("WUT_PASSWD", "你的密码")
 interval = int(os.getenv("CHECK_INTERVAL", 600))  # Default interval is 600 seconds
+log_level = int(os.getenv("LOG_LEVEL", 1))  # Default log level is 1 (verbose logs)
 ```
 
 ### 3. 使用 Docker
 
 ```sh
-docker pull somebottle/whut-online-keeper:0.2
+docker pull somebottle/whut-online-keeper:0.3
 
 # --restart unless-stopped 在进程意外终止 / 关机重启 / Docker Daemon 重启等情况下自动重启
 docker run -d --name whut-online-keeper \
     --restart unless-stopped \
     -e WUT_USERID='100110' \
     -e WUT_PASSWD='El_psy_kongroo' \
-    -e CHECK_INTERVAL=60 \
-    somebottle/whut-online-keeper:0.2
+    -e CHECK_INTERVAL=120 \
+    -e LOG_LEVEL=1 \
+    somebottle/whut-online-keeper:0.3
 ```

--- a/wut-login.py
+++ b/wut-login.py
@@ -455,7 +455,7 @@ class Login(object):
                     self.log_printer.verbose("Failed")
                     self.log_printer.info(
                         self.get_current_time()
-                        + " Login failed (Most probably due to wrong nasId), code: "
+                        + " Login failed, code: "
                         + str(parsed_info["code"])
                         + ", message: "
                         + parsed_info["msg"]

--- a/wut-login.py
+++ b/wut-login.py
@@ -143,9 +143,22 @@ class Login(object):
             end="",
         )
         for _ in range(max_iters):
-            response = requests.get(
-                next_url, allow_redirects=False, timeout=30, proxies={}
-            )
+            try:
+                response = requests.get(
+                    next_url, allow_redirects=False, timeout=30, proxies={}
+                )
+            except Exception as e:
+                self.log_printer.verbose("Failed")
+                self.log_printer.info(self.get_current_time() + " Error:" + str(e))
+                self.log_printer.info(
+                    self.get_current_time()
+                    + " If you are using TUN-based proxy (via virtual NIC), try to disable it"
+                )
+                self.log_printer.info(
+                    self.get_current_time()
+                    + " 如果你在使用基于 TUN (虚拟网卡) 的代理，请将其关闭"
+                )
+                return
             if 300 <= response.status_code < 400:
                 next_location = response.headers.get("Location", "")
                 if next_location:

--- a/wut-login.py
+++ b/wut-login.py
@@ -1,18 +1,18 @@
 """
- Copyright 2023 lxidea @https://github.com/lxidea
+Copyright 2023 lxidea @https://github.com/lxidea
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- """
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 # -*- coding: utf-8 -*-
 """
@@ -21,252 +21,495 @@ usage: put your password and WUT accountID assigned to the variables below,
 default online status checking interval is 600 seconds.
 To use this python script, you will need python3, and packages: json, requests
 """
-#-*- coding:utf-8 -*-
-userid = ''
-passwd = ''
-interval = 600
+# -*- coding:utf-8 -*-
 
-__author__ = 'lxidea'
 import time
 import requests
-import re
+import os
 import json
 import sys
+import re
 from requests.cookies import RequestsCookieJar
 from requests.exceptions import ConnectTimeout
+from urllib.parse import urlparse, parse_qs
+
+userid = os.getenv("WUT_USERID", "")  # Read from environment variable by default
+passwd = os.getenv("WUT_PASSWD", "")
+interval = int(os.getenv("CHECK_INTERVAL", 600))  # Default interval is 600 seconds
+
+__author__ = "lxidea"
+__refactorer__ = "somebottle"
+
+# Match comments in JavaScript
+PATTERN_COMMENTS = re.compile(r"//.*?\n|/\*.*?\*/", re.DOTALL)
+# Match API base path in 'tpl/whut/static/js/config.js'
+PATTERN_API_BASE_PATH = re.compile(r"host_url\s*=\s*['\"](.*?)['\"]")
+# Domain used to follow the redirect to get the host and nasId
+TEST_DOMAIN = "neverssl.com"
+
+# Should bypass the proxy
+os.environ["NO_PROXY"] = ",".join(os.getenv("NO_PROXY", "").split(",") + [TEST_DOMAIN])
+os.environ["no_proxy"] = ",".join(os.getenv("no_proxy", "").split(",") + [TEST_DOMAIN])
+
+
+class SimplePrinter(object):
+    """
+    Simple printer class to print messages with different log levels
+    """
+
+    def __init__(self, log_level=0):
+        """
+        Init the SimplePrinter class
+
+        :param log_level: Log level, if greater than 0, will show more logs
+        """
+        self.log_level = log_level
+
+    def verbose(self, msg, end="\n", flush=True):
+        """
+        Print verbose messages if log level is greater than 0
+
+        :param msg: Message to print
+        :param end: End character for the print function
+        :param flush: Whether to flush the output immediately
+        """
+        if self.log_level > 0:
+            print(msg, end=end)
+            if flush:
+                sys.stdout.flush()
+
+    def info(self, msg, end="\n", flush=True):
+        """
+        Print info messages
+
+        :param msg: Message to print
+        :param end: End character for the print function
+        :param flush: Whether to flush the output immediately
+        """
+        print(msg, end=end)
+        if flush:
+            sys.stdout.flush()
+
 
 class Login(object):
-     """login class in charge of keep your device online on WUT campus"""
-     def __init__(self):
-          super(Login).__init__()
-          self.interval = interval
-          self.online = None
-          self.network = None
-          self.cookies = requests.cookies.RequestsCookieJar()
-          self.host_url = ''
-          self.host = '172.30.21.100'
-          self.staturl = '/account/status'
-          self.info = None
-          self.loginfo = None
-          self.__version__ = 'v0.1'
-          self.loglevel = 0
-          self.shown = False
+    """login class in charge of keep your device online on WUT campus"""
 
-     def getCurrentTime(self):
-          return time.strftime('[%Y-%m-%d %H:%M:%S]',time.localtime(time.time()))
+    def __init__(self, userid, passwd, interval=600, log_level=0):
+        """
+        Init the Login class
 
-     def showLine(self,msg,length=0,char=None):
-          msg = msg.strip()
-          if type(msg) is not str:
-               msg = str(msg)
-          if not char:
-               char = '*'
-          if length<=0:
-               length=30
-          strlen=len(msg)
-          if strlen>length:
-               raise(Exception('msg is too long'))
-          charlen = length - strlen
-          charlen2 = int(charlen/2)
-          if charlen2*2!=charlen:
-               charlen2=charlen2-1
-          for x in range(charlen2):
-               print(char,end='')
-          print(msg,end='')
-          if charlen2*2!=charlen:
-               print(' ',end='')
-          for x in range(charlen2):
-               print(char,end='')
-          print('')
+        :param userid: WUT account ID
+        :param passwd: WUT account password
+        :param interval: Interval for checking online status in seconds
+        :param log_level: Log level, if greater than 0, will show more logs
+        """
+        super(Login).__init__()
+        self.userid = userid
+        self.passwd = passwd
+        self.interval = interval
+        self.nas_id = ""  # NAS ID for WUT Campus Network, will be fetched by 'fetch_host_and_nas_id'
+        self.online = None
+        self.network = None
+        self.cookies = RequestsCookieJar()
+        self.api_base_path = "/api"  # API Base Path, will be updated by 'check'
+        self.host = "172.30.21.100"  # Host of WUT Campus Network Portal, will be updated by 'fetch_host_and_nas_id'
+        self.status_endpoint = "/account/status"
+        self.info = None
+        self.login_info = None
+        self.log_printer = SimplePrinter(log_level)
+        self.log_level = log_level
+        self.shown = False  # Only show login info once during the session
+        self.__version__ = "v0.2"
 
-     def showLoginfo(self):
-          if not self.loginfo:
-               print(self.getCurrentTime()+' not login yet.')
-               return
-          self.showLine('First Appear Time:'+self.loginfo['AddTime'],50)
-          self.showLine('User Name:'+self.loginfo['Name'],50)
-          self.showLine('Network Address:'+self.loginfo['UserIpv4'],50)
-          self.showLine('Mac Address:'+self.loginfo['UserMac'],50)
-          self.showLine('UserSourceType:'+self.loginfo['UserSourceType'],50)
-          self.showLine('UserId:'+self.loginfo['Username'],50)
+    def get_current_time(self):
+        return time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime(time.time()))
 
-     def check(self):
-          url = "http://"+self.host+"/tpl/whut/login.html?nasId=14"
-          headers={
-            'Host': self.host,
-            'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-            'Referer': "http://"+self.host+"/",
-            'Accept-Encoding': "gzip, deflate",
-            'Accept-Language': "en-US,en;q=0.5",
-            'Connection': "keep-alive",
-            'Upgrade-Insecure-Requests': "1",
-            'User-Agent':"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0"
-          }
-          self.data = None
-          if self.loglevel>0:
-               print(self.getCurrentTime()+'First Handshake...',end='')
-          sys.stdout.flush()
-          try:
-               self.data = requests.get(url,headers=headers,cookies=self.cookies,timeout=5)
-               self.cookies.update(self.data.cookies)
-          except ConnectTimeout as c:
-               print('\n'+self.getCurrentTime()+'TimeOut when trying to connect to portal')
-               print('maybe you are off campus')
-               self.network = False
-               self.online = False
-               return
-          except Exception as e:
-               print('\n'+self.getCurrentTime()+'Error:'+str(e))
-               self.network = False
-               self.online = False
-               return
-          if self.data.status_code == 200:
-               if self.loglevel>0:
-                    print('OK')
-                    sys.stdout.flush()
-               self.network = True
-          url = "http://"+self.host+"/tpl/whut/static/js/config.js"
-          headers={
-            'Host': self.host,
-            'Accept': "*/*",
-            'Referer': "http://"+self.host+"/tpl/whut/login.html?nasId=14",
-            'Accept-Encoding': "gzip, deflate",
-            'Accept-Language': "en-US,en;q=0.5",
-            'Connection': "keep-alive",
-            'User-Agent':"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0"
-          }
-          self.data = None
-          if self.loglevel>0:
-               print(self.getCurrentTime()+'get conn path...',end='')
-               sys.stdout.flush()
-          try:
-               self.data = requests.get(url,headers=headers,cookies=self.cookies,timeout=5)
-               self.cookies.update(self.data.cookies)
-               raw_text = self.data.text
-               if self.data.status_code == 200:
-                    if self.loglevel>0:
-                         print('OK')
-                         sys.stdout.flush()
-                    self.network = True
-               for line in raw_text.split('\n'):
-                    if not (line.startswith('//') or len(line.strip())==0):
-                         sline = [x.strip() for x in line.strip().replace('var','').strip().split('=')]
-                         execstr = 'self.'+sline[0]+'='+sline[1]
-                         #print('setting '+sline[0]+' to '+sline[1])
-                         exec(execstr)
-          except Exception as e:
-               print(self.getCurrentTime()+'Error:'+str(e))
-               self.network = False
-               self.online = False
-          url = 'http://'+self.host+self.host_url+self.staturl+'?token=null'
-          headers={
-            'Host': self.host,
-            'Accept': "*/*",
-            'Referer': "http://"+self.host+"/tpl/whut/login.html?nasId=14",
-            'Accept-Encoding': "gzip, deflate",
-            'Accept-Language': "en-US,en;q=0.5",
-            'Connection': "keep-alive",
-            'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
-            'X-Requested-With': "XMLHttpRequest"
-          }
-          data={
-            'token': "null"
-          }
-          self.data = None
-          print(self.getCurrentTime()+' get online status...',end='')
-          sys.stdout.flush()
-          try:
-               self.data = requests.get(url,headers=headers,cookies=self.cookies,timeout=5)
-               self.cookies.update(self.data.cookies)
-               if self.data.status_code == 200:
-                    print('OK')
-                    sys.stdout.flush()
-                    self.network = True
-                    try:
-                         self.info = json.loads(self.data.text)
-                         self.online = self.info['code']==0
-                         self.loginfo = self.info['online']
-                         if self.loglevel>0 and not self.shown:
-                              self.showLoginfo()
-                              self.shown = True
-                    except Exception as e:
-                         if self.loglevel>0:
-                              print(self.getCurrentTime()+'Error:'+str(e))
-                         self.json = None
-                         print(self.getCurrentTime()+' Account Status Fetching Failure.')
-                         self.online = False
-                         return
-          except Exception as e:
-               print(self.getCurrentTime()+'Error:'+str(e))
-               self.network = False
-               self.online = False
+    def fetch_host_and_nas_id(self, max_iters=10):
+        """
+        Follow the redirect to fetch the host and NAS ID from the WUT portal.
 
-     def login(self):
-          url='http://'+self.host+self.host_url+'/account/login'
-          logindata={
-          'username':userid,
-          'password':passwd,
-          'swtichip': '',
-          'nasId': "14",
-          'userIpv4': "",
-          'userMac': "",
-          'captcha': '',
-          'captchaId': '',
-          }
-          # code 0: success, 1 error, 2 code wrong
-          headers={
-            'Host': self.host,
-            'Accept': "*/*",
-            'Referer': "http://"+self.host+"/tpl/whut/login.html?nasId=14",
-            'Accept-Encoding': "gzip, deflate",
-            'Accept-Language': "en-US,en;q=0.5",
-            'Connection': "keep-alive",
-            'Content-Length': '94',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Origin': 'http://'+self.host,
-            'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
-            'X-Requested-With': "XMLHttpRequest"
-          }
-          if self.loglevel>0:
-               print(self.getCurrentTime()+' try login...',end='')
-               sys.stdout.flush()
-          try:
-               self.data = requests.post(url,headers=headers,data=logindata,cookies=self.cookies,timeout=5)
-               self.cookies.update(self.data.cookies)
-               if self.data.status_code == 200:
-                    if self.loglevel>0:
-                         print('OK')
-                         sys.stdout.flush()
-                    self.network = True
-                    print(self.getCurrentTime()+' success, now we\'re online')
-                    #try:
-                    self.info = json.loads(self.data.text)
-                    self.online = self.info['code']
-                    self.loginfo = self.info['online']
-                    if self.loglevel>0 and not self.shown:
-                         self.showLoginfo()
-                         self.shown = True
-                    #except Exception as e:
-                    #     raise e
-                    
-          except Exception as e:
-               raise e
-     
-     def run(self):
-          print(self.getCurrentTime()+' WUT Network Online Status Keeper '+self.__version__)
-          print(self.getCurrentTime()+' written by '+__author__)
-          while True:
-               self.check()
-               if not self.online:
-                    print(self.getCurrentTime()+' offline, try login')
-                    self.login()
-                    #try:
-                    #     self.login()
-                    #except Exception as e:
-                    #     print(self.getCurrentTime()+' Error:'+str(e))
-               else:
-                    print(self.getCurrentTime()+' we\'re good, sleep for '+str(self.interval)+' seconds')
-               time.sleep(self.interval)
-if __name__ == '__main__':
-     login = Login()
-     login.run()
+        :param max_iters: Maximum number of iterations to follow redirects
+        """
+        if self.online:
+            return
+        test_url = (
+            "http://" + TEST_DOMAIN
+        )  # A URL that won't redirect if the network is available
+        next_url = test_url
+        portal_url = ""
+        self.log_printer.verbose(
+            self.get_current_time()
+            + " Trying to get host and nasId from WUT portal...",
+            end="",
+        )
+        for _ in range(max_iters):
+            response = requests.get(
+                next_url, allow_redirects=False, timeout=30, proxies={}
+            )
+            if 300 <= response.status_code < 400:
+                next_location = response.headers.get("Location", "")
+                if next_location:
+                    portal_url = next_location
+                    next_url = next_location
+                else:
+                    self.log_printer.verbose("Failed")
+                    self.log_printer.info(
+                        self.get_current_time()
+                        + " Status code: "
+                        + str(response.status_code)
+                        + ", but no Location header found, this is unexpected!"
+                    )
+                    return
+            elif response.status_code >= 400:
+                self.log_printer.verbose("Failed")
+                self.log_printer.info(
+                    self.get_current_time()
+                    + " Status code: "
+                    + str(response.status_code)
+                    + " while getting host and nasId, this is unexpected!"
+                )
+                return
+            else:
+                # Status 200
+                break
+
+        if portal_url:
+            parsed_url = urlparse(portal_url)
+            self.host = parsed_url.netloc
+            params = parse_qs(parsed_url.query)
+            if "nasId" in params:
+                self.nas_id = params["nasId"][0]
+                self.log_printer.verbose(
+                    "OK, nasId: " + self.nas_id + ", host: " + self.host
+                )
+            else:
+                self.log_printer.verbose("Failed")
+                self.log_printer.info(
+                    self.get_current_time() + " No nasId found in the redirected URL!"
+                )
+                return
+        else:
+            self.log_printer.verbose("Failed")
+            self.log_printer.info(
+                self.get_current_time() + " No redirect found, this is unexpected!"
+            )
+            return
+
+    def show_line(self, msg, length=0, char=None):
+        """
+        Show a center-aligned message with padding characters.
+
+        :param msg: The message to display
+        :param length: The total length of the line
+        :param char: The character to use for padding
+        """
+        msg = msg.strip()
+        if type(msg) is not str:
+            msg = str(msg)
+        if not char:
+            char = "*"
+        if length <= 0:
+            length = 30
+        strlen = len(msg)
+        if strlen > length:
+            raise (Exception("msg is too long"))
+        charlen = length - strlen
+        charlen2 = int(charlen / 2)
+        if charlen2 * 2 != charlen:
+            charlen2 = charlen2 - 1
+        for x in range(charlen2):
+            print(char, end="")
+        print(msg, end="")
+        if charlen2 * 2 != charlen:
+            print(" ", end="")
+        for x in range(charlen2):
+            print(char, end="")
+        print("")
+
+    def show_login_info(self):
+        """
+        Display the login information of the user.
+        """
+        if not self.login_info:
+            self.log_printer.info(self.get_current_time() + " User not logged in yet")
+            return
+        print()
+        self.show_line("Login Information", 50, "#")
+        self.show_line("First Appear Time:" + self.login_info["AddTime"], 50)
+        self.show_line("User Name:" + self.login_info["Name"], 50)
+        self.show_line("Network Address:" + self.login_info["UserIpv4"], 50)
+        self.show_line("Mac Address:" + self.login_info["UserMac"], 50)
+        self.show_line("UserSourceType:" + self.login_info["UserSourceType"], 50)
+        self.show_line("UserId:" + self.login_info["Username"], 50)
+        print()
+
+    def check(self):
+        """
+        Check the online status of the user
+
+        1. Perform a handshake with the WUT portal to get cookies.
+        2. Fetch the API base path from the JavaScript configuration file.
+        3. Get the online information of the user.
+        """
+        url = "http://" + self.host + "/tpl/whut/login.html?nasId=" + self.nas_id
+        headers = {
+            "Host": self.host,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Referer": "http://" + self.host + "/",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
+        }
+        self.log_printer.verbose("First Handshake...", end="")
+        try:
+            response = requests.get(
+                url, headers=headers, cookies=self.cookies, timeout=5
+            )
+            self.cookies.update(response.cookies)
+        except ConnectTimeout as c:
+            self.log_printer.info(
+                "\n"
+                + self.get_current_time()
+                + " Timeout when trying to connect to the portal"
+                + ", maybe you are off campus"
+            )
+            self.network = False
+            self.online = False
+            return
+        except Exception as e:
+            self.log_printer.info("\n" + self.get_current_time() + " Error: " + str(e))
+            self.network = False
+            self.online = False
+            return
+        if response.status_code == 200:
+            self.log_printer.verbose("OK")
+            self.network = True
+        else:
+            self.log_printer.verbose("Failed")
+        # Get API Base Path
+        url = "http://" + self.host + "/tpl/whut/static/js/config.js"
+        headers = {
+            "Host": self.host,
+            "Accept": "*/*",
+            "Referer": "http://"
+            + self.host
+            + "/tpl/whut/login.html?nasId="
+            + self.nas_id,
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Connection": "keep-alive",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
+        }
+        self.log_printer.verbose(
+            self.get_current_time() + " Get API base path...", end=""
+        )
+        try:
+            response = requests.get(
+                url, headers=headers, cookies=self.cookies, timeout=5
+            )
+            self.cookies.update(response.cookies)
+            raw_text = response.text
+            self.network = True
+            extract_success = False
+            if response.status_code == 200:
+                self.log_printer.verbose("OK")
+                # Extract API base path from the JavaScript file
+                pruned_raw_text = PATTERN_COMMENTS.sub("", raw_text)  # Remove comments
+                match = PATTERN_API_BASE_PATH.search(pruned_raw_text)
+                if match:
+                    self.api_base_path = match.group(1).strip()
+                    self.log_printer.verbose(
+                        self.get_current_time()
+                        + " API base path found: "
+                        + self.api_base_path
+                    )
+                    extract_success = True
+            if not extract_success:
+                self.log_printer.verbose("Failed")
+                self.log_printer.verbose(
+                    self.get_current_time()
+                    + " Status code: "
+                    + str(response.status_code)
+                    + ", API base path not found, using default: "
+                    + self.api_base_path
+                )
+        except Exception as e:
+            self.log_printer.info(self.get_current_time() + " Error: " + str(e))
+            self.network = False
+            self.online = False
+        # Get Online Status
+        url = (
+            "http://"
+            + self.host
+            + self.api_base_path
+            + self.status_endpoint
+            + "?token=null"
+        )
+        headers = {
+            "Host": self.host,
+            "Accept": "*/*",
+            "Referer": "http://"
+            + self.host
+            + "/tpl/whut/login.html?nasId="
+            + self.nas_id,
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Connection": "keep-alive",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        # data = {"token": "null"}
+        self.log_printer.info(self.get_current_time() + " Get online status...", end="")
+        try:
+            response = requests.get(
+                url, headers=headers, cookies=self.cookies, timeout=5
+            )
+            self.cookies.update(response.cookies)
+            if response.status_code == 200:
+                self.log_printer.info("OK")
+                self.network = True
+                try:
+                    self.info = json.loads(response.text)
+                    self.online = self.info["code"] == 0
+                    self.login_info = self.info["online"]
+                    if self.log_level > 0 and not self.shown:
+                        self.show_login_info()
+                        self.shown = True  # Show only once during the session
+                except Exception as e:
+                    self.log_printer.verbose(
+                        self.get_current_time() + " Error: " + str(e)
+                    )
+                    self.info = None
+                    self.log_printer.info(
+                        self.get_current_time() + " Account status fetching failure"
+                    )
+                    self.online = False
+                    return
+            else:
+                self.log_printer.verbose("Failed")
+        except Exception as e:
+            self.log_printer.info(self.get_current_time() + " Error: " + str(e))
+            self.network = False
+            self.online = False
+
+    def login(self):
+        """
+        Login to the gate
+        """
+        # First, fetch the host and nasId
+        self.fetch_host_and_nas_id()
+        url = "http://" + self.host + self.api_base_path + "/account/login"
+        login_data = {
+            "username": self.userid,
+            "password": self.passwd,
+            "swtichip": "",
+            "nasId": self.nas_id,
+            "userIpv4": "",
+            "userMac": "",
+            "captcha": "",
+            "captchaId": "",
+        }
+        # code 0: success, 1 error, 2 code wrong
+        headers = {
+            "Host": self.host,
+            "Accept": "*/*",
+            "Referer": "http://"
+            + self.host
+            + "/tpl/whut/login.html?nasId="
+            + self.nas_id,
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Connection": "keep-alive",
+            "Content-Length": "94",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Origin": "http://" + self.host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/110.0",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        self.log_printer.verbose(self.get_current_time() + " Try login...", end="")
+        try:
+            response = requests.post(
+                url, headers=headers, data=login_data, cookies=self.cookies, timeout=5
+            )
+            self.cookies.update(response.cookies)
+            if response.status_code == 200:
+                parsed_info = json.loads(response.text)
+                if parsed_info["code"] != 0:
+                    # If nasId is incorrect, the code will be 1 and login will fail
+                    self.log_printer.verbose("Failed")
+                    self.log_printer.info(
+                        self.get_current_time()
+                        + " Login failed (Most probably due to wrong nasId), code: "
+                        + str(parsed_info["code"])
+                        + ", message: "
+                        + parsed_info["msg"]
+                    )
+                    self.network = False
+                    self.online = False
+                    return
+                self.network = True
+                self.log_printer.verbose("OK")
+                self.log_printer.info(
+                    self.get_current_time()
+                    + " Successfully logged in, now we're online"
+                )
+                self.info = parsed_info
+                self.online = self.info["code"]
+                self.login_info = self.info["online"]
+                if self.log_level > 0 and not self.shown:
+                    self.show_login_info()
+                    self.shown = True
+            else:
+                self.log_printer.verbose("Failed")
+
+        except Exception as e:
+            raise e
+
+    def run(self):
+        """
+        Run online status keeper
+        """
+        self.log_printer.info(
+            self.get_current_time()
+            + " WUT Network Online Status Keeper "
+            + self.__version__
+        )
+        self.log_printer.info(
+            self.get_current_time()
+            + " Written by "
+            + __author__
+            + " (Refactor: "
+            + __refactorer__
+            + ")"
+        )
+        while True:
+            self.check()
+            if not self.online:
+                # Reset shown flag
+                self.shown = False
+                self.log_printer.info(self.get_current_time() + " Offline, try login")
+                self.login()
+                # try:
+                #     self.login()
+                # except Exception as e:
+                #     print(self.getCurrentTime()+' Error:'+str(e))
+            else:
+                self.log_printer.info(
+                    self.get_current_time()
+                    + " We're good, sleep for "
+                    + str(self.interval)
+                    + " seconds"
+                )
+            time.sleep(self.interval)
+
+
+if __name__ == "__main__":
+    if userid.strip() == "" or passwd.strip() == "":
+        print(
+            "Please set your WUT account ID and password with environment variables 'WUT_USERID' and 'WUT_PASSWD'"
+        )
+        sys.exit(1)
+    login = Login(userid, passwd, interval, log_level=1)
+    login.run()

--- a/wut-login.py
+++ b/wut-login.py
@@ -225,7 +225,8 @@ class Login(object):
             length = 30
         strlen = len(msg)
         if strlen > length:
-            raise (Exception("msg is too long"))
+            print(msg)
+            return
         charlen = length - strlen
         charlen2 = int(charlen / 2)
         if charlen2 * 2 != charlen:

--- a/wut-login.py
+++ b/wut-login.py
@@ -398,12 +398,12 @@ class Login(object):
             self.network = True
             extract_success = False
             if response.status_code == 200:
-                self.log_printer.verbose("OK", with_time=False)
                 # Extract API base path from the JavaScript file
                 pruned_raw_text = PATTERN_COMMENTS.sub("", raw_text)  # Remove comments
                 match = PATTERN_API_BASE_PATH.search(pruned_raw_text)
                 if match:
                     self.api_base_path = match.group(1).strip()
+                    self.log_printer.verbose("OK", with_time=False)
                     self.log_printer.verbose(
                         "API base path found: " + self.api_base_path
                     )
@@ -452,12 +452,12 @@ class Login(object):
                 url, headers=headers, cookies=self.cookies, timeout=5
             )
             if response.status_code == 200:
-                self.log_printer.info("OK", with_time=False)
                 self.network = True
                 try:
                     self.info = json.loads(response.text)
                     self.online = self.info["code"] == 0
                     self.login_info = self.info["online"]
+                    self.log_printer.info("OK", with_time=False)
                     if self.log_level > 0 and not self.shown:
                         self.show_login_info()
                         self.shown = True  # Show only once during the session


### PR DESCRIPTION
最近暑期准备回家了，想让实验室服务器一直保持在线，故找到了这个自动登录脚本。  
不过测试时发现不太可用，主要原因是脚本中把登录用的 `nasId` 给固定了。    

![image](https://github.com/user-attachments/assets/5bbbcc4e-f88a-4681-8e36-a3dcc4907092)    

`nasId` 用于标识当前本机接入的校园网网关设备，如果使用了错误的标识则会在登录时提示：  

![b5096bdb-dc87-4d54-80b3-ae5443670ca3](https://github.com/user-attachments/assets/95527e66-aa24-4f75-bcc8-033856378a28)   

因此我在脚本中加入了自动获取 `nasId` 和校园网登录入口地址的 `fetch_host_and_nas_id` 方法来解决这点，核心原理是访问一个在线情况下能正常访问的 URL，如果发生了跳转 (3xx) 则跟随其直至跳转到校园网登录页面，此时在 URL 中可以截取到 `nasId`。  

-----------   

除此之外我还进行了以下修改：  

1. 部分变量名规范化，添加注释。
2. 修改一些小地方，比如 `self.json` 改为 `self.info`，`self.data` 改为函数域的 `response` 变量等。
3. 支持从环境变量读取用户名和密码。
4. `loglevel` 相关输出封装成 `SimplePrinter`，稍微减少一些代码冗余度。  
5. 增加一些登录失败的输出逻辑。  
6. 增加 Docker 镜像，方便拉取使用。  


感谢你编写了这个很实用的脚本，我也很高兴能为这个脚本做出些贡献。  @lxidea 